### PR TITLE
Load in secrets at run time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM node:alpine
 
+ARG GITHUB_TOKEN
+
+RUN apk add --update \
+    python \
+    python-dev \
+    py-pip \
+    git
+
+RUN pip install --upgrade pip
+
+RUN pip install "git+https://${GITHUB_TOKEN}@github.com/callrail/secretmgmt.git"
+
 WORKDIR /usr/src/app
 
 # Install app dependencies
@@ -13,4 +25,7 @@ RUN npm install
 COPY . .
 
 EXPOSE 3000
+
+ENTRYPOINT ["./entrypoint.sh"]
+
 CMD [ "npm", "start" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/ash
+
+if [ "$LOAD_SECRETS" = 'true' ]; then
+  # Load secrets into environment
+  SECRETS=$(secretmgmt env export --stdout --service ringobot --env $ENV)
+
+  # Only run the export statments and the
+  # command if the secretmgmt command succeeded 
+  if [ $? == 0 ]; then
+    export $(echo $SECRETS | grep '^export [a-zA-Z0-9_]*=[^ ]*' | sed 's/^export //' | xargs)
+    "$@"
+  else
+    echo "Secrets were not able to be imported"
+  fi
+else
+  echo "Secrets not imported"
+  "$@"
+fi


### PR DESCRIPTION
# Changes
1. You need to use a github_token to access callrail private repos
https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
2. Pass the token in at build time
`docker build -t callrail/ringobot --build-arg GITHUB_TOKEN=$GITHUB_TOKEN .`
3. Run as normal, passing secrets at run time.
4. To load secrets from secretmgmt
Note, the container needs to run with an IAM role in this case, or you need to inject aws credentials
`docker run -it -e LOAD_SECRETS=true -e ENV=production callrail/ringobot:latest`
